### PR TITLE
fix competition update loss of data

### DIFF
--- a/src/Judge/NTS.Judge/Core/Behinds/CompetitionParentContext.cs
+++ b/src/Judge/NTS.Judge/Core/Behinds/CompetitionParentContext.cs
@@ -7,14 +7,11 @@ namespace NTS.Judge.Core.Behinds;
 
 public class CompetitionParentContext : BehindContext<Competition>, ICrudParent<Phase>, ICrudParent<Participation>
 {
-    readonly ObservableList<Phase> _phases = new();
-    readonly ObservableList<Participation> _participations = new();
-
     public CompetitionParentContext(IRepository<Competition> competitionRepository)
         : base(competitionRepository) { }
 
-    ObservableList<Phase> ICrudParent<Phase>.Children => _phases;
-    ObservableList<Participation> ICrudParent<Participation>.Children => _participations;
+    IReadOnlyList<Phase> ICrudParent<Phase>.Children => Entity!.Phases;
+    IReadOnlyList<Participation> ICrudParent<Participation>.Children => Entity!.Participations;
 
     public async Task Add(Phase child)
     {

--- a/src/Judge/NTS.Judge/Core/Behinds/EventParentContext.cs
+++ b/src/Judge/NTS.Judge/Core/Behinds/EventParentContext.cs
@@ -1,20 +1,16 @@
 ﻿using Not.Application.Behinds;
 using Not.Application.CRUD.Ports;
-using Not.Structures;
 using NTS.Domain.Setup.Aggregates;
 
 namespace NTS.Judge.Core.Behinds;
 
 public class EventParentContext : BehindContext<EnduranceEvent>, ICrudParent<Competition>, ICrudParent<Official>
 {
-    readonly ObservableList<Competition> _competitions = new();
-    readonly ObservableList<Official> _officials = new();
-
     public EventParentContext(IUpdate<EnduranceEvent> updater)
         : base(updater) { }
 
-    ObservableList<Competition> ICrudParent<Competition>.Children => _competitions;
-    ObservableList<Official> ICrudParent<Official>.Children => _officials;
+    IReadOnlyList<Competition> ICrudParent<Competition>.Children => Entity!.Competitions;
+    IReadOnlyList<Official> ICrudParent<Official>.Children => Entity!.Officials;
 
     public async Task Add(Competition child)
     {

--- a/src/NTS.Domain/Extensions/DomainExtensions.cs
+++ b/src/NTS.Domain/Extensions/DomainExtensions.cs
@@ -9,7 +9,7 @@ public static class DomainExtensions
         where T : AggregateRoot
     {
         var index = collection.IndexOf(entity);
-        if(index == -1)
+        if (index == -1)
         {
             throw GuardHelper.Exception("Empty collections cannot be updated");
         }

--- a/src/NTS.Domain/Extensions/DomainExtensions.cs
+++ b/src/NTS.Domain/Extensions/DomainExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Not.Domain.Base;
+using Not.Exceptions;
 
 namespace NTS.Domain.Extensions;
 
@@ -8,6 +9,10 @@ public static class DomainExtensions
         where T : AggregateRoot
     {
         var index = collection.IndexOf(entity);
+        if(index == -1)
+        {
+            throw GuardHelper.Exception("Empty collections cannot be updated");
+        }
         collection.Remove(entity);
         collection.Insert(index, entity);
     }

--- a/src/Not/Not.Application/Behinds/ICrudParent.cs
+++ b/src/Not/Not.Application/Behinds/ICrudParent.cs
@@ -7,7 +7,7 @@ namespace Not.Application.Behinds;
 public interface ICrudParent<T> : ICrudParentContext
     where T : AggregateRoot
 {
-    ObservableList<T> Children { get; }
+    IReadOnlyList<T> Children { get; }
     Task Add(T child);
     Task Update(T child);
     Task Remove(T child);


### PR DESCRIPTION
fixing the discussed bug where a click of the Update button of the Competition Form result into loss of configure Phases and Participations data