### PR TITLE
Add non-blocking persistence for Snapshot selection

### DIFF
--- a/src/Apps/Judge/NTS.Judge/Features/UserSessions/EmptyJudgeUserSessionService.cs
+++ b/src/Apps/Judge/NTS.Judge/Features/UserSessions/EmptyJudgeUserSessionService.cs
@@ -13,6 +13,11 @@ internal class EmptyJudgeUserSessionService : IWitnessUserSession, IScoped
         return Task.CompletedTask;
     }
 
+    public Task ReplaceSnapshotSelections(IReadOnlyCollection<Snapshot> snapshots)
+    {
+        return Task.CompletedTask;
+    }
+
     public Task DeleteCurrent()
     {
         return Task.CompletedTask;

--- a/src/Apps/Witness/NTS.Witness.Blazor/Layout/MainLayoutBehind.cs
+++ b/src/Apps/Witness/NTS.Witness.Blazor/Layout/MainLayoutBehind.cs
@@ -9,5 +9,5 @@ public class MainLayoutBehind : LayoutComponentBase
     NEnvironment Environment { get; set; } = default!;
 
     protected string LayoutWatermark =>
-        NtsClientDisplayFormatter.FormatTitle(ApplicationConstants.Apps.WITNESS, Environment);
+        NtsClientDisplayFormatter.FormatTitle(ApplicationConstants.NO_TIMING_SYSTEM, Environment);
 }

--- a/src/Apps/Witness/NTS.Witness/Features/Core/Dashboard/SnapshotService.cs
+++ b/src/Apps/Witness/NTS.Witness/Features/Core/Dashboard/SnapshotService.cs
@@ -35,8 +35,10 @@ public class SnapshotService
     readonly IEventScopedRepository<Participation> _participationReader;
     readonly List<Participation> _participationsToSnapshot = [];
     readonly ISnapshotPublisher _snapshotPublisher;
+    readonly object _snapshotSelectionPersistenceLock = new();
     readonly List<Snapshot> _snapshots = [];
     readonly IWitnessUserSession _userSessionService;
+    Task _snapshotSelectionPersistence = Task.CompletedTask;
 
     public SnapshotService(
         INtsSocketContext socketContext,
@@ -63,10 +65,12 @@ public class SnapshotService
             return false;
         }
 
-        var participations = await _participationReader.ReadMany(x => !x.IsComplete() && !x.IsEliminated());
+        var participations = (await _participationReader.ReadMany(x => !x.IsComplete() && !x.IsEliminated())).ToList();
         var session = await _userSessionService.GetCurrent();
 
         _allParticipations.Clear();
+        _participationsToSnapshot.Clear();
+        _snapshots.Clear();
         foreach (var participation in participations)
         {
             _allParticipations[participation.Combination.Number] = participation;
@@ -74,7 +78,11 @@ public class SnapshotService
 
         _history.Clear();
         _history.AddRange(session?.GetSnapshotHistory() ?? []);
-        Participations.ClearAndAddRange(participations);
+
+        var selectedNumbers = RestoreSnapshotSelections(session?.GetSnapshotSelections() ?? []);
+        Participations.ClearAndAddRange(
+            participations.Where(participation => !selectedNumbers.Contains(participation.Combination.Number))
+        );
 
         return Participations.Any() || _participationsToSnapshot.Any() || _history.Any();
     }
@@ -104,6 +112,7 @@ public class SnapshotService
             )
         );
         Participations.Remove(participation);
+        QueueSnapshotSelectionPersistence();
         EmitChanged();
     }
 
@@ -117,6 +126,7 @@ public class SnapshotService
         }
 
         FlushSnapshots([snapshot.Number]);
+        QueueSnapshotSelectionPersistence();
         EmitChanged();
     }
 
@@ -130,6 +140,7 @@ public class SnapshotService
 
         var snapshotGroup = new SnapshotGroup(readySnapshots, snapshotType);
         await _snapshotPublisher.PublishSnapshotsAsync(snapshotGroup);
+        await DrainSnapshotSelectionPersistence();
         await _userSessionService.AppendSnapshot(snapshotGroup);
 
         _history.Add(snapshotGroup);
@@ -157,6 +168,7 @@ public class SnapshotService
         }
 
         existingSnapshot.Timestamp = timestamp;
+        QueueSnapshotSelectionPersistence();
         EmitChanged();
     }
 
@@ -247,5 +259,100 @@ public class SnapshotService
         }
 
         Participations.Update(participation, action);
+    }
+
+    HashSet<int> RestoreSnapshotSelections(IReadOnlyList<Snapshot> snapshots)
+    {
+        var selectedNumbers = new HashSet<int>();
+        foreach (var snapshot in snapshots)
+        {
+            if (
+                selectedNumbers.Contains(snapshot.Number)
+                || !_allParticipations.TryGetValue(snapshot.Number, out var participation)
+            )
+            {
+                continue;
+            }
+
+            selectedNumbers.Add(snapshot.Number);
+            _participationsToSnapshot.Add(participation);
+            _snapshots.Add(CopySnapshot(snapshot));
+        }
+
+        return selectedNumbers;
+    }
+
+    void QueueSnapshotSelectionPersistence()
+    {
+        var snapshots = _snapshots.Select(CopySnapshot).ToArray();
+
+        lock (_snapshotSelectionPersistenceLock)
+        {
+            _snapshotSelectionPersistence = PersistSnapshotSelectionsAfter(_snapshotSelectionPersistence, snapshots);
+        }
+    }
+
+    async Task PersistSnapshotSelectionsAfter(Task previous, IReadOnlyCollection<Snapshot> snapshots)
+    {
+        await Task.Yield();
+
+        try
+        {
+            await previous;
+        }
+        catch
+        {
+            // Previous selection persistence is intentionally best effort.
+        }
+
+        try
+        {
+            await _userSessionService.ReplaceSnapshotSelections(snapshots);
+        }
+        catch
+        {
+            // Snapshot selection persistence must not block witness timing flow.
+        }
+    }
+
+    async Task DrainSnapshotSelectionPersistence()
+    {
+        while (true)
+        {
+            var persistence = GetSnapshotSelectionPersistence();
+
+            try
+            {
+                await persistence;
+            }
+            catch
+            {
+                // Background persistence failures are intentionally ignored.
+            }
+
+            if (ReferenceEquals(persistence, GetSnapshotSelectionPersistence()))
+            {
+                return;
+            }
+        }
+    }
+
+    Task GetSnapshotSelectionPersistence()
+    {
+        lock (_snapshotSelectionPersistenceLock)
+        {
+            return _snapshotSelectionPersistence;
+        }
+    }
+
+    static Snapshot CopySnapshot(Snapshot snapshot)
+    {
+        return new Snapshot(
+            snapshot.Number,
+            snapshot.Name,
+            snapshot.NameEnglish,
+            snapshot.Timestamp == null ? null : Timestamp.Copy(snapshot.Timestamp),
+            snapshot.Ruleset
+        );
     }
 }

--- a/src/Apps/Witness/NTS.Witness/Features/Sessions/WitnessUserSessionService.cs
+++ b/src/Apps/Witness/NTS.Witness/Features/Sessions/WitnessUserSessionService.cs
@@ -62,6 +62,7 @@ public class WitnessUserSessionService : IWitnessUserSession, IScoped
     public async Task AppendSnapshot(SnapshotGroup snapshot)
     {
         ArgumentNullException.ThrowIfNull(snapshot);
+        var sentNumbers = snapshot.Entries.Select(entry => entry.Number).ToHashSet();
 
         var userSession = await _nUserSessionService.GetCurrent<NtsUserSessionStateModel>();
         if (userSession == null || _eventId == null)
@@ -83,6 +84,34 @@ public class WitnessUserSessionService : IWitnessUserSession, IScoped
 
         var currentState = currentSession.State?.Copy() ?? new NtsUserSessionStateModel();
         currentState.SnapshotHistory = [.. currentState.SnapshotHistory, SnapshotGroupModel.MapFrom(snapshot)];
+        currentState.SnapshotSelections = currentState
+            .SnapshotSelections.Where(selection => !sentNumbers.Contains(selection.Number))
+            .ToArray();
+        currentSession.ReplaceState(currentState);
+        await _userSessions.Update(currentSession);
+    }
+
+    public async Task ReplaceSnapshotSelections(IReadOnlyCollection<Snapshot> snapshots)
+    {
+        ArgumentNullException.ThrowIfNull(snapshots);
+
+        var userSession = await _nUserSessionService.GetCurrent<NtsUserSessionStateModel>();
+        if (userSession == null || _eventId == null)
+        {
+            return;
+        }
+
+        var currentSession = await _userSessions.ReadByUserIdentifier(userSession.UserIdentifier, _eventId.Value);
+        var currentState = currentSession?.State?.Copy() ?? new NtsUserSessionStateModel();
+        currentState.SnapshotSelections = snapshots.Select(SnapshotModel.MapFrom).ToArray();
+
+        if (currentSession == null)
+        {
+            currentSession = CreateSession(userSession, _eventId.Value, currentState);
+            await _userSessions.Create(currentSession);
+            return;
+        }
+
         currentSession.ReplaceState(currentState);
         await _userSessions.Update(currentSession);
     }

--- a/src/NTS.Application.Contracts/ApplicationConstants.cs
+++ b/src/NTS.Application.Contracts/ApplicationConstants.cs
@@ -2,12 +2,13 @@
 
 public static class ApplicationConstants
 {
-    public const string VERSION = "1.2.7";
+    public const string VERSION = "1.2.8";
     public const string VERSION_STRING = "NTS v" + VERSION;
     public const int NETWORK_BROADCAST_PORT = 21337;
     public const string JUDGE_HUB = "judge-hub";
     public const string WITNESS_HUB = "witness-hub";
     public const int RPC_PORT = 11337;
+    public const string NO_TIMING_SYSTEM = "NoTiming";
 
     public static class Apps
     {

--- a/src/NTS.Application.Contracts/NtsClientDisplayFormatter.cs
+++ b/src/NTS.Application.Contracts/NtsClientDisplayFormatter.cs
@@ -12,7 +12,7 @@ public static class NtsClientDisplayFormatter
     public static string FormatTitle(string appName, string? environment)
     {
         var normalizedEnvironment = NEnvionmentNames.Normalize(environment);
-        var title = $"NTS {appName} v{ApplicationConstants.VERSION}";
+        var title = $"{appName} v{ApplicationConstants.VERSION}";
 
         return normalizedEnvironment == NEnvionmentNames.PRODUCTION ? $"{title}" : $"{title} [{normalizedEnvironment}]";
     }

--- a/src/NTS.Application.Contracts/Watcher/Models/NtsUserSessionStateModel.cs
+++ b/src/NTS.Application.Contracts/Watcher/Models/NtsUserSessionStateModel.cs
@@ -11,10 +11,16 @@ namespace NTS.Application.Contracts.Watcher.Models;
 public class NtsUserSessionStateModel
 {
     public SnapshotGroupModel[] SnapshotHistory { get; set; } = [];
+    public SnapshotModel[] SnapshotSelections { get; set; } = [];
 
     public IReadOnlyList<SnapshotGroup> GetSnapshotHistory()
     {
         return SnapshotHistory.Select(x => x.MapToDomain()).ToArray();
+    }
+
+    public IReadOnlyList<Snapshot> GetSnapshotSelections()
+    {
+        return SnapshotSelections.Select(x => x.MapToDomain()).ToArray();
     }
 
     public NtsUserSessionStateModel Copy()
@@ -22,6 +28,7 @@ public class NtsUserSessionStateModel
         return new NtsUserSessionStateModel
         {
             SnapshotHistory = SnapshotHistory.Select(group => group.Copy()).ToArray(),
+            SnapshotSelections = SnapshotSelections.Select(snapshot => snapshot.Copy()).ToArray(),
         };
     }
 }

--- a/src/NTS.Application.Contracts/Watcher/Models/SnapshotModel.cs
+++ b/src/NTS.Application.Contracts/Watcher/Models/SnapshotModel.cs
@@ -22,11 +22,11 @@ public class SnapshotModel
     public string Name { get; set; } = default!;
     public string? NameEnglish { get; set; }
     public CompetitionRuleset? Ruleset { get; set; }
-    public string? Timestamp { get; set; } = "";
+    public string? Timestamp { get; set; }
 
     public Snapshot MapToDomain()
     {
-        var timestamp = Timestamp == null ? null : new Timestamp(Timestamp);
+        var timestamp = string.IsNullOrWhiteSpace(Timestamp) ? null : new Timestamp(Timestamp);
         return new Snapshot(Number, Name, NameEnglish, timestamp, Ruleset);
     }
 

--- a/src/NTS.Application/UserSession/IUserSessionService.cs
+++ b/src/NTS.Application/UserSession/IUserSessionService.cs
@@ -9,5 +9,6 @@ public interface IWitnessUserSession
     Task<NtsUserSessionStateModel?> GetCurrent();
     Task SetEventId(int? eventId);
     Task AppendSnapshot(SnapshotGroup snapshot);
+    Task ReplaceSnapshotSelections(IReadOnlyCollection<Snapshot> snapshots);
     Task DeleteCurrent();
 }

--- a/tests/NTS.Tests.Integration/Drivers/NexusApiDriver.cs
+++ b/tests/NTS.Tests.Integration/Drivers/NexusApiDriver.cs
@@ -4,6 +4,7 @@ using Not.Application.HTTP;
 using Not.Serialization.JSON;
 using Not.Structures;
 using NTS.Application.Contracts.Core.Models;
+using NTS.Application.Contracts.Watcher.Models;
 using NTS.Domain.Core.Aggregates;
 using NTS.Tests.Integration.Infrastructure;
 using NTS.Witness.Contracts.API;
@@ -216,6 +217,15 @@ internal sealed class NexusApiDriver : IDisposable
             EventFilter("api/snapshot-results", eventId)
         );
         return models.ToArray();
+    }
+
+    public Task<NtsUserSessionModel?> ReadUserSession(string userIdentifier, int eventId)
+    {
+        var encodedUserIdentifier = Uri.EscapeDataString(userIdentifier);
+        return SendNullable<NtsUserSessionModel>(
+            HttpMethod.Get,
+            $"api/user-sessions/{eventId}/by-user-identifier/{encodedUserIdentifier}"
+        );
     }
 
     public async Task<IReadOnlyList<SetupClub>> ReadSetupClubs()

--- a/tests/NTS.Tests.Integration/IntegrationHarnessCheckTest.cs
+++ b/tests/NTS.Tests.Integration/IntegrationHarnessCheckTest.cs
@@ -206,9 +206,7 @@ public sealed class IntegrationHarnessCheckTest : IClassFixture<NtsIntegrationFi
 
         var snapshots = witness.GetRequiredService<WitnessSnapshotService>();
         await snapshots.Load();
-        snapshots.SelectForSnapshot(
-            snapshots.Participations.Single(x => x.Combination.Number == participationNumber)
-        );
+        snapshots.SelectForSnapshot(snapshots.Participations.Single(x => x.Combination.Number == participationNumber));
 
         await WaitForUserSession(
             api,
@@ -252,10 +250,7 @@ public sealed class IntegrationHarnessCheckTest : IClassFixture<NtsIntegrationFi
         var restoredSnapshot = restoredSnapshots.Snapshots.Single(x => x.Number == participationNumber);
 
         Assert.Equal(expectedTimestamp, restoredSnapshot.Timestamp?.ToString());
-        Assert.DoesNotContain(
-            restoredSnapshots.Participations,
-            x => x.Combination.Number == participationNumber
-        );
+        Assert.DoesNotContain(restoredSnapshots.Participations, x => x.Combination.Number == participationNumber);
         Assert.True(await restoredSnapshots.Publish(SnapshotType.Arrive));
 
         var publishedSession = await WaitForUserSession(
@@ -265,8 +260,7 @@ public sealed class IntegrationHarnessCheckTest : IClassFixture<NtsIntegrationFi
             state =>
                 state.SnapshotSelections.Length == 0
                 && state.SnapshotHistory.Any(group =>
-                    group.Type == SnapshotType.Arrive
-                    && group.Entries.Any(entry => entry.Number == participationNumber)
+                    group.Type == SnapshotType.Arrive && group.Entries.Any(entry => entry.Number == participationNumber)
                 ),
             "clear sent selections and append the snapshot history"
         );
@@ -275,8 +269,7 @@ public sealed class IntegrationHarnessCheckTest : IClassFixture<NtsIntegrationFi
         Assert.Contains(
             publishedSession.State.SnapshotHistory,
             group =>
-                group.Type == SnapshotType.Arrive
-                && group.Entries.Any(entry => entry.Number == participationNumber)
+                group.Type == SnapshotType.Arrive && group.Entries.Any(entry => entry.Number == participationNumber)
         );
     }
 

--- a/tests/NTS.Tests.Integration/IntegrationHarnessCheckTest.cs
+++ b/tests/NTS.Tests.Integration/IntegrationHarnessCheckTest.cs
@@ -4,6 +4,7 @@ using Not.Application.Authentication.User;
 using NTS.Application.Contracts.Arrivelists;
 using NTS.Application.Contracts.Core;
 using NTS.Application.Contracts.Presentlists;
+using NTS.Application.Contracts.Watcher.Models;
 using NTS.Domain.Core.Objects.Arrivelists;
 using NTS.Domain.Core.Objects.Presentlists;
 using NTS.Domain.Aggregates;
@@ -27,6 +28,7 @@ using SetupParticipation = NTS.Domain.Setup.Aggregates.ConfigureEvents.Participa
 using SetupPhase = NTS.Domain.Setup.Aggregates.ConfigureEvents.Phase;
 using SetupUser = NTS.Domain.Setup.Aggregates.User;
 using WitnessSnapshot = NTS.Domain.Watcher.Snapshot;
+using WitnessSnapshotService = NTS.Witness.Contracts.Features.Snapshots.ISnapshotService;
 
 namespace NTS.Tests.Integration;
 
@@ -169,6 +171,113 @@ public sealed class IntegrationHarnessCheckTest : IClassFixture<NtsIntegrationFi
 
         Assert.True(persistedParticipation.Phases.Current.IsComplete());
         Assert.Equal(3, persistedSnapshotResults.Count);
+    }
+
+    [Fact]
+    public async Task Witness_snapshot_selections_restore_from_user_session_until_published()
+    {
+        var eventId = 1901;
+        var participationNumber = 61;
+        var timestamp = DateTimeOffset.UtcNow.Date.AddHours(11).AddMinutes(17);
+        var expectedTimestamp = new Timestamp(timestamp).ToString();
+        var eventInformation = IntegrationPayloadFactory.EventInformation(eventId);
+        var participation = IntegrationPayloadFactory.ActiveParticipation(
+            eventId,
+            participationNumber,
+            id: 5701,
+            startTime: timestamp.AddHours(-2)
+        );
+        using var api = new NexusApiDriver(_fixture.NexusBaseUrl);
+
+        var officialUser = await api.RegisterUser(OFFICIAL_USER);
+        await api.Create(eventInformation);
+        await api.Create(participation);
+        await api.Create(IntegrationPayloadFactory.Official(eventId, officialUser.Id, id: 6701));
+
+        await using var witness = new WitnessDriver(
+            _fixture.WarpBaseUrl,
+            _fixture.NexusBaseUrl,
+            OFFICIAL_USER,
+            "SnapshotSessionWitness"
+        );
+
+        await witness.Start();
+        await witness.Connect(eventInformation);
+
+        var snapshots = witness.GetRequiredService<WitnessSnapshotService>();
+        await snapshots.Load();
+        snapshots.SelectForSnapshot(
+            snapshots.Participations.Single(x => x.Combination.Number == participationNumber)
+        );
+
+        await WaitForUserSession(
+            api,
+            OFFICIAL_USER.UserIdentifier,
+            eventId,
+            state =>
+                state.SnapshotSelections.Length == 1
+                && state.SnapshotSelections[0].Number == participationNumber
+                && state.SnapshotSelections[0].Timestamp == null,
+            "persist the selected snapshot without a timestamp"
+        );
+
+        var selectedSnapshot = snapshots.Snapshots.Single(x => x.Number == participationNumber);
+        snapshots.UpdateTimestamp(selectedSnapshot, new Timestamp(timestamp));
+
+        await WaitForUserSession(
+            api,
+            OFFICIAL_USER.UserIdentifier,
+            eventId,
+            state =>
+                state.SnapshotSelections.Length == 1
+                && state.SnapshotSelections[0].Number == participationNumber
+                && state.SnapshotSelections[0].Timestamp == expectedTimestamp,
+            "persist the captured snapshot timestamp"
+        );
+
+        await witness.Disconnect();
+
+        await using var restoredWitness = new WitnessDriver(
+            _fixture.WarpBaseUrl,
+            _fixture.NexusBaseUrl,
+            OFFICIAL_USER,
+            "SnapshotSessionRestoredWitness"
+        );
+
+        await restoredWitness.Start();
+        await restoredWitness.Connect(eventInformation);
+
+        var restoredSnapshots = restoredWitness.GetRequiredService<WitnessSnapshotService>();
+        await restoredSnapshots.Load();
+        var restoredSnapshot = restoredSnapshots.Snapshots.Single(x => x.Number == participationNumber);
+
+        Assert.Equal(expectedTimestamp, restoredSnapshot.Timestamp?.ToString());
+        Assert.DoesNotContain(
+            restoredSnapshots.Participations,
+            x => x.Combination.Number == participationNumber
+        );
+        Assert.True(await restoredSnapshots.Publish(SnapshotType.Arrive));
+
+        var publishedSession = await WaitForUserSession(
+            api,
+            OFFICIAL_USER.UserIdentifier,
+            eventId,
+            state =>
+                state.SnapshotSelections.Length == 0
+                && state.SnapshotHistory.Any(group =>
+                    group.Type == SnapshotType.Arrive
+                    && group.Entries.Any(entry => entry.Number == participationNumber)
+                ),
+            "clear sent selections and append the snapshot history"
+        );
+
+        Assert.Empty(publishedSession.State!.SnapshotSelections);
+        Assert.Contains(
+            publishedSession.State.SnapshotHistory,
+            group =>
+                group.Type == SnapshotType.Arrive
+                && group.Entries.Any(entry => entry.Number == participationNumber)
+        );
     }
 
     [Fact]
@@ -725,6 +834,52 @@ public sealed class IntegrationHarnessCheckTest : IClassFixture<NtsIntegrationFi
         throw new TimeoutException(
             $"Witness Arrivelist did not {expectedState}. Entries: {string.Join(", ", last.Select(x => x.Number))}."
         );
+    }
+
+    static async Task<NtsUserSessionModel> WaitForUserSession(
+        NexusApiDriver api,
+        string userIdentifier,
+        int eventId,
+        Func<NtsUserSessionStateModel, bool> predicate,
+        string expectedState
+    )
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+        NtsUserSessionModel? last = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            last = await api.ReadUserSession(userIdentifier, eventId);
+            if (last?.State != null && predicate(last.State))
+            {
+                return last;
+            }
+
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException(
+            $"Witness user session did not {expectedState}. {FormatUserSessionState(last?.State)}"
+        );
+    }
+
+    static string FormatUserSessionState(NtsUserSessionStateModel? state)
+    {
+        if (state == null)
+        {
+            return "No session state was returned.";
+        }
+
+        var selections = string.Join(
+            ", ",
+            state.SnapshotSelections.Select(selection => $"#{selection.Number}@{selection.Timestamp ?? "<pending>"}")
+        );
+        var history = string.Join(
+            ", ",
+            state.SnapshotHistory.Select(group =>
+                $"{group.Type}: {string.Join(", ", group.Entries.Select(entry => $"#{entry.Number}"))}"
+            )
+        );
+        return $"Selections: [{selections}]. History: [{history}].";
     }
 
     static SnapshotGroup CreateSnapshotGroup()

--- a/tests/NTS.Tests.Unit/Temporary/NtsUserSessionStateModelTests.cs
+++ b/tests/NTS.Tests.Unit/Temporary/NtsUserSessionStateModelTests.cs
@@ -26,10 +26,7 @@ public sealed class NtsUserSessionStateModelTests
             SnapshotHistory =
             [
                 SnapshotGroupModel.MapFrom(
-                    new SnapshotGroup(
-                        [new Snapshot(7, "Sent Rider", "Sent Rider", sentTimestamp)],
-                        SnapshotType.Arrive
-                    )
+                    new SnapshotGroup([new Snapshot(7, "Sent Rider", "Sent Rider", sentTimestamp)], SnapshotType.Arrive)
                 ),
             ],
         };

--- a/tests/NTS.Tests.Unit/Temporary/NtsUserSessionStateModelTests.cs
+++ b/tests/NTS.Tests.Unit/Temporary/NtsUserSessionStateModelTests.cs
@@ -1,0 +1,50 @@
+using NTS.Application.Contracts.Watcher.Models;
+using NTS.Domain.Enums;
+using NTS.Domain.Objects;
+using NTS.Domain.Watcher;
+
+namespace NTS.Tests.Unit.Temporary;
+
+public sealed class NtsUserSessionStateModelTests
+{
+    [Fact]
+    public void Copy_preserves_snapshot_selections_and_history()
+    {
+        var sentTimestamp = new Timestamp(DateTimeOffset.UtcNow.Date.AddHours(9));
+        var model = new NtsUserSessionStateModel
+        {
+            SnapshotSelections =
+            [
+                new SnapshotModel
+                {
+                    Number = 5,
+                    Name = "Pending Rider",
+                    NameEnglish = "Pending Rider",
+                    Timestamp = null,
+                },
+            ],
+            SnapshotHistory =
+            [
+                SnapshotGroupModel.MapFrom(
+                    new SnapshotGroup(
+                        [new Snapshot(7, "Sent Rider", "Sent Rider", sentTimestamp)],
+                        SnapshotType.Arrive
+                    )
+                ),
+            ],
+        };
+
+        var copy = model.Copy();
+
+        Assert.NotSame(model.SnapshotSelections, copy.SnapshotSelections);
+        Assert.NotSame(model.SnapshotHistory, copy.SnapshotHistory);
+        Assert.Equal(5, copy.SnapshotSelections.Single().Number);
+        Assert.Null(copy.SnapshotSelections.Single().Timestamp);
+        Assert.Equal(7, copy.SnapshotHistory.Single().Entries.Single().Number);
+        Assert.Equal(sentTimestamp.ToString(), copy.SnapshotHistory.Single().Entries.Single().Timestamp);
+
+        copy.SnapshotSelections[0].Name = "Changed";
+
+        Assert.Equal("Pending Rider", model.SnapshotSelections.Single().Name);
+    }
+}


### PR DESCRIPTION
 If a user logs out or is forced to signin in the middle of an active event they could lose valuable data - The pre-selected snapshot list (inlcuding any captured timestamps). To that end we've implemented a non-blocking persistence:
 - both the list and captured timestamps are recorded in a separate array in the UserSession event-scoped object
 - non-blocking because I don't want these time sensitive operations to be blocked by HTTP input/output